### PR TITLE
WIP: don't forget to request the pull scope

### DIFF
--- a/lib/docker/remote/auth_info.rb
+++ b/lib/docker/remote/auth_info.rb
@@ -2,7 +2,7 @@ module Docker
   module Remote
     class AuthInfo
       class << self
-        def from_header(header, creds)
+        def from_header(header, creds, repo)
           idx = header.index(' ')
           auth_type = header[0..idx].strip.downcase
 
@@ -11,23 +11,24 @@ module Docker
             ret[key.strip] = value.strip[1..-2]  # remove quotes
           end
 
-          new(auth_type, params, creds)
+          new(auth_type, params, creds, repo)
         end
       end
 
 
-      attr_reader :auth_type, :params, :creds
+      attr_reader :auth_type, :params, :creds, :repo
 
-      def initialize(auth_type, params, creds)
+      def initialize(auth_type, params, creds, repo)
         @auth_type = auth_type
         @params = params
         @creds = creds
+        @repo = repo
       end
 
       def strategy
         @strategy ||= case auth_type
           when 'bearer'
-            BearerAuth.new(self, creds)
+            BearerAuth.new(self, creds, repo)
           when 'basic'
             BasicAuth.new(creds)
           else

--- a/lib/docker/remote/bearer_auth.rb
+++ b/lib/docker/remote/bearer_auth.rb
@@ -7,11 +7,12 @@ module Docker
     class BearerAuth
       include Utils
 
-      attr_reader :auth_info, :creds
+      attr_reader :auth_info, :creds, :repo
 
-      def initialize(auth_info, creds)
+      def initialize(auth_info, creds, repo)
         @auth_info = auth_info
         @creds = creds
+        @repo = repo
       end
 
       def make_get(path)
@@ -27,7 +28,7 @@ module Docker
       end
 
       def service
-        @serivce ||= auth_info.params['service']
+        @service ||= auth_info.params['service']
       end
 
       def token
@@ -35,7 +36,7 @@ module Docker
           http = Net::HTTP.new(realm.host, realm.port)
           http.use_ssl = true if realm.scheme == 'https'
 
-          url_params = { service: service }
+          url_params = { service: service, scope: "repository:#{repo}:pull" }
 
           if scope = auth_info.params['scope']
             url_params[:scope] = scope

--- a/lib/docker/remote/client.rb
+++ b/lib/docker/remote/client.rb
@@ -67,7 +67,7 @@ module Docker
       end
 
       def www_auth(response)
-        AuthInfo.from_header(response['www-authenticate'], creds)
+        AuthInfo.from_header(response['www-authenticate'], creds, repo)
       end
 
       def get(path, http: registry_http, use_auth: auth, limit: 5)


### PR DESCRIPTION
Harbor will deny tags/list if you did not request the pull scope

(I do not know how scopes are supposed to be assigned, but when I debugged the conversation that happens in `kuby build` today, I came up against this issue on my public harbor registry)

This brilliant fellow explains the conversation and how it's intended to happen, and the conversation continues in the gist linked from there... https://stackoverflow.com/a/51921869/661659

I am not sure what's the correct way to determine the scope, or how to best pass the repo in so the repo scope can be requested, but this version resulted in a 200/ok for me.

Also, hey! LTNS